### PR TITLE
ci: migrate 3 of 7 jobs to smithy self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit Checks
+    # Stays on ubuntu-latest: actions/setup-python + system pip install
+    # of pre-commit interacts with smithy's preinstalled Python 3.12 in
+    # ways we haven't validated yet (no `--user` flag, no venv). Keep
+    # here until we have a clean recipe.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -45,6 +49,9 @@ jobs:
 
   test:
     name: Test Suite
+    # Stays on ubuntu-latest: cross-OS matrix (ubuntu/macos/windows).
+    # Smithy is Linux-only; splitting per-OS would lose the per-PR
+    # signal that all three platforms still build.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -71,6 +78,9 @@ jobs:
 
   build:
     name: Build & Verify
+    # Stays on ubuntu-latest: cross-OS matrix (linux/macos-13/macos-14/
+    # windows). Smithy is Linux-only; the matrix exists precisely to
+    # validate the four release-target OSes.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -125,7 +135,7 @@ jobs:
 
   clippy:
     name: Clippy Lints
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -143,7 +153,7 @@ jobs:
 
   format:
     name: Formatting Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -158,6 +168,9 @@ jobs:
 
   security:
     name: Security Audit
+    # Stays on ubuntu-latest: cargo-audit advisory parser on smithy
+    # (v0.21.2) rejects CVSS 4.0 advisories (RUSTSEC-2026-0037). Move
+    # back once smithy bumps cargo-audit to 0.22.1+.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -177,7 +190,7 @@ jobs:
 
   validation:
     name: Template Validation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Moves the three Linux-only single-host jobs of `ci.yml` (`clippy`,
`format`, `validation`) to the pulseengine self-hosted fleet
(smithy). The four jobs that stay on `ubuntu-latest` either span a
cross-OS matrix (`test`, `build`), depend on tooling that is not yet
clean on smithy (`pre-commit`'s pip-installed Python tooling), or hit
a known smithy-side issue (`security`'s cargo-audit advisory parser).
The release pipeline (`npm-publish.yml`) is left untouched: every job
is either a cross-OS build matrix or a Node-only publish step that
runs once per tag, so the smithy compute win is negligible.

## Coverage

| Job | New runner | Class |
|---|---|---|
| `clippy` | smithy | `rust-cpu` |
| `format` | smithy | `light` |
| `validation` | smithy | `light` |

## Stays on ubuntu-latest

| Job | Reason |
|---|---|
| `pre-commit` | `actions/setup-python` + system `pip install pre-commit detect-secrets` interacts with smithy's preinstalled Python 3.12 in ways we haven't validated yet (no `--user`, no venv). Keep here until the recipe is clean. |
| `test` | Cross-OS matrix (`ubuntu-latest`, `macos-latest`, `windows-latest`); the matrix exists to validate per-PR coverage on all three. |
| `build` | Cross-OS release-target matrix (`ubuntu-latest`, `macos-13`, `macos-14`, `windows-latest`). |
| `security` | `cargo-audit` advisory parser shipped on smithy (v0.21.2) rejects CVSS 4.0 advisories (RUSTSEC-2026-0037). Move back once smithy bumps cargo-audit to 0.22.1+. |

## Workarounds applied

None — the three migrated jobs are clean `runs-on:` swaps. No
installer scripts, no sudo, no `cargo-deny-action` /
`cargo-semver-checks-action` / `free-disk-space` patterns.

## Test plan

- [ ] CI run completes; the three migrated jobs land on the matching
      smithy runner class within seconds (no GitHub queue).
- [ ] `clippy` succeeds end-to-end on `rust-cpu`.
- [ ] `format`, `validation` succeed on `light`.
- [ ] `pre-commit`, `test`, `build`, `security` still run on
      `ubuntu-latest` exactly as before.

## Rollback

Revert this commit. Every migrated job returns to `ubuntu-latest` and
the next run uses GitHub-hosted compute.